### PR TITLE
Fix jackson-databind version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>{jackson-databind.version}</version>
+                <version>${jackson-databind.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
Running `mvn clean install` fails due to the following error:

```
Could not resolve dependencies for project io.github.deweyjose:common:jar:0.0.1-SNAPSHOT: The following artifacts could
not be resolved: com.fasterxml.jackson.core:jackson-databind:jar:{jackson-databind.version} (absent):
com.fasterxml.jackson.core:jackson-databind:jar:{jackson-databind.version} was not found in
https://repo.maven.apache.org/maven2 during a previous attempt. This failure was cached in the local repository and
resolution is not reattempted until the update interval of central has elapsed or updates are forced -> [Help 1]
```

The jackson-databind.version cannot be resolved.